### PR TITLE
Swift 5 compatible Swift Package definition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,8 +36,7 @@ playground.xcworkspace
 # Swift Package Manager
 #
 # Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
-# Packages/
-# Package.pins
+.swiftpm/
 .build/
 
 # CocoaPods

--- a/CodableKeychain.podspec
+++ b/CodableKeychain.podspec
@@ -13,6 +13,7 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = '10.10'
   s.tvos.deployment_target = '9.0'
   s.watchos.deployment_target = '2.0'
+  s.swift_versions = ['4.2', '5.0']
 
   s.source_files = 'Sources/*.swift'
 end

--- a/Package@swift-4.2.swift
+++ b/Package@swift-4.2.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:4.2
 //
 //  Package.swift
 //
@@ -27,12 +27,6 @@ import PackageDescription
 
 let package = Package(
     name: "CodableKeychain",
-    platforms: [
-        .iOS(.v9),
-        .tvOS(.v9),
-        .macOS(.v10_10),
-        .watchOS(.v2)
-    ],
     products: [
         .library(
             name: "CodableKeychain",
@@ -45,9 +39,5 @@ let package = Package(
             path: "Sources",
             exclude: ["Info.plist"]
         )
-    ],
-    swiftLanguageVersions: [
-        .v4_2,
-        .v5
     ]
 )

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CodableKeychain
 
-![CocoaPods Version](https://cocoapod-badges.herokuapp.com/v/CodableKeychain/badge.png) [![Swift](https://img.shields.io/badge/swift-4.2-orange.svg?style=flat)](https://developer.apple.com/swift/) ![Platform](https://cocoapod-badges.herokuapp.com/p/CodableKeychain/badge.png) [![Swift Package Manager compatible](https://img.shields.io/badge/SPM-compatible-4BC51D.svg?style=flat)](https://github.com/apple/swift-package-manager) [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
+![CocoaPods Version](https://cocoapod-badges.herokuapp.com/v/CodableKeychain/badge.png) [![Swift](https://img.shields.io/badge/swift-5.0_4.2-orange.svg?style=flat)](https://developer.apple.com/swift/) ![Platform](https://cocoapod-badges.herokuapp.com/p/CodableKeychain/badge.png) [![Swift Package Manager compatible](https://img.shields.io/badge/SPM-compatible-4BC51D.svg?style=flat)](https://github.com/apple/swift-package-manager) [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 
 ## Overview
 
@@ -83,7 +83,7 @@ do {
 
 ## Installation
 
-> _Note:_ CodableKeychain requires Swift 4 (and [Xcode][] 9) or greater.
+> _Note:_ CodableKeychain requires Swift 4.2 (and [Xcode][] 10) or greater.
 >
 > Targets using CodableKeychain must support embedded Swift frameworks.
 


### PR DESCRIPTION
Adds a Swift 5 compatible Swift Package definition while maintaining a Swift 4.2 compatible Package definition using [version-specific manifest selection](https://github.com/apple/swift-package-manager/blob/main/Documentation/Usage.md#version-specific-manifest-selection)

Closes https://github.com/toddkramer/CodableKeychain/issues/5